### PR TITLE
Fix: Mapeamento CreateUserRequest and UpdateUserRequest

### DIFF
--- a/src/back-end/PlantCare.Application/Mapping/UserProfile.cs
+++ b/src/back-end/PlantCare.Application/Mapping/UserProfile.cs
@@ -11,10 +11,16 @@ public class UserProfile : Profile
     public UserProfile()
     {
         CreateMap<User, UserDto>();
-        CreateMap<CreateUserRequest, User>();
+        CreateMap<CreateUserRequest, User>()
+            .ForMember(dest => dest.Active, o => o
+                .MapFrom(src => true));
         CreateMap<User, CreateUpdateUserDtoResponse>();
         CreateMap<UpdateUserRequest, User>()
+            .ForMember(
+                dest => dest.Active, o => o
+                    .MapFrom(src => true))
             .ForAllMembers(
-                o => o.Condition((src, dest, srcMember) => srcMember != null));
+                o => o
+                    .Condition((src, dest, srcMember) => srcMember != null));
     }
 }


### PR DESCRIPTION
Ao mapear Requests de Update e CreateUser para a entidade User o valor da propriedade IsActive será sempre true.