### PR TITLE
Implementar:  endpoint DELETE /users/{id} para atualizar usuários como inativos

### DIFF
--- a/src/back-end/PlantCare.API/Controllers/UserController.cs
+++ b/src/back-end/PlantCare.API/Controllers/UserController.cs
@@ -22,6 +22,19 @@ namespace Plantcare.API.Controllers
             _createValidator = createValidator;
             _updateValidator = updateValidator;
         }
+
+        [HttpDelete("{id:long}")]
+        public async Task<IActionResult> DeleteAsync(long id)
+        {
+            var result = await _userService.DeleteAsync(id);
+
+            if (!result)
+            {
+                return NotFound();
+            }
+            
+            return Ok();
+        }
         
         [HttpPost]
         public async Task<IActionResult> CreateAsync([FromBody] CreateUserRequest request)

--- a/src/back-end/PlantCare.Application/Users/Interfaces/IUserService.cs
+++ b/src/back-end/PlantCare.Application/Users/Interfaces/IUserService.cs
@@ -8,8 +8,10 @@ public interface IUserService
 {
     Task<CreateUpdateUserDtoResponse> CreateAsync(CreateUserRequest req);
     Task<CreateUpdateUserDtoResponse> UpdateAsync(UpdateUserRequest req);
+    Task<bool> DeleteAsync(long id);
     Task<List<UserDto>> GetAllAsync();
     Task<UserDto?> GetByIdAsync(long id);
+    Task<bool> ExistsAsync(long id);
     Task<UserDto?> GetByUsername(string username);
     Task<bool> DoesEmailExist(string email);
     Task<bool> DoesUsernameExist(string username);

--- a/src/back-end/PlantCare.Application/Users/Services/UserService.cs
+++ b/src/back-end/PlantCare.Application/Users/Services/UserService.cs
@@ -55,6 +55,19 @@ public class UserService : IUserService
         return _mapper.Map<CreateUpdateUserDtoResponse>(patchedUser);
     }
 
+    public async Task<bool> DeleteAsync(long id)
+    {
+        var existingUser = await _userRepository.ExistsAsync(id);
+        
+        if (!existingUser)
+        {
+            return false;
+        }
+        var result = await _userRepository.DeleteAsync(id);
+        
+        return true;
+    }
+    
     public async Task<List<UserDto>> GetAllAsync()
     {
         var usersEntities = await _userRepository.GetAllAsync();
@@ -87,4 +100,5 @@ public class UserService : IUserService
     
     public async Task<bool> DoesEmailExist(string email) => await _userRepository.DoesEmailExist(email);
     public async Task<bool> DoesUsernameExist(string username) => await _userRepository.DoesUsernameExist(username);
+    public async Task<bool> ExistsAsync(long id) => await _userRepository.ExistsAsync(id);
 }

--- a/src/back-end/PlantCare.Domain/Repositories/IBaseRepository.cs
+++ b/src/back-end/PlantCare.Domain/Repositories/IBaseRepository.cs
@@ -11,4 +11,5 @@ public interface IBaseRepository<TEntity> where TEntity : BaseEntity
     Task<bool> DeleteAsync(long id);
     Task<List<TEntity>> GetAllAsync();
     Task<TEntity?> GetByIdAsync(long id);
+    Task<bool> ExistsAsync(long id);
 }

--- a/src/back-end/PlantCare.Infra/Repositories/UserRepository.cs
+++ b/src/back-end/PlantCare.Infra/Repositories/UserRepository.cs
@@ -32,10 +32,21 @@ public class UserRepository : IUserRepository
         
         return updatedUser.Entity;
     }
-
+    
     public async Task<bool> DeleteAsync(long id)
     {
-        throw new NotImplementedException();
+        var user = await _dbContext.Users.FindAsync(id);
+
+        if (user == null)
+        {
+            return false;
+        }
+            
+        user.Active = false;
+        _dbContext.Users.Update(user);
+        await _dbContext.SaveChangesAsync();
+
+        return true;
     }
 
     public async Task<List<User>> GetAllAsync()
@@ -80,5 +91,12 @@ public class UserRepository : IUserRepository
         Console.WriteLine($"checking email {email} - {result}");
 
         return result;
+    }
+
+    public async Task<bool> ExistsAsync(long id)
+    {
+        var result = await _dbContext.Users.FindAsync(id);
+        
+        return result != null;
     }
 }


### PR DESCRIPTION
Este PR implementa um endpoint na rota Users com verbo DELETE.

O endpoint não deleta o usuário da tabela "users", ele apenas atualiza a coluna "is_active" para "false".