### PR TITLE
Implementando separação das configurações das tabelas no Infra por classes

### DIFF
--- a/src/back-end/PlantCare.API/Program.cs
+++ b/src/back-end/PlantCare.API/Program.cs
@@ -34,15 +34,9 @@ builder.Services.AddScoped<UpdateUserRequestValidator>();
 builder.Services.AddScoped<IUserService, UserService>();
 builder.Services.AddScoped<IUserRepository, UserRepository>();
 
-Console.WriteLine("Enter the db password");
-var dbPassword = Console.ReadLine();
-
-var dbConnectionString = $"{builder.Configuration.GetConnectionString("EnterPasswordConnection")}{dbPassword}";
-Console.WriteLine(dbConnectionString);
-
 builder.Services.AddDbContext<PlantCareDbContext>(options =>
 {
-    options.UseNpgsql(dbConnectionString);
+    options.UseNpgsql(builder.Configuration.GetConnectionString("DefaultConnection"));
 });
 
 var app = builder.Build();

--- a/src/back-end/PlantCare.API/appsettings.Development.json
+++ b/src/back-end/PlantCare.API/appsettings.Development.json
@@ -6,6 +6,6 @@
     }
   },
   "ConnectionStrings": {
-    "EnterPasswordConnection": "Host=localhost;Database=plantcare;Username=postgres;Password="
+    "DefaultConnection": "Host=localhost;Database=plantcare;Username=postgres;Password=admin"
   }
 }

--- a/src/back-end/PlantCare.Infra/Configurations/PlantsConfiguration.cs
+++ b/src/back-end/PlantCare.Infra/Configurations/PlantsConfiguration.cs
@@ -1,0 +1,45 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using PlantCare.Domain.Entities;
+
+namespace PlantCare.Infra.Configurations;
+
+public class PlantsConfiguration : IEntityTypeConfiguration<Plant>
+{
+    public void Configure(EntityTypeBuilder<Plant> builder)
+    {
+        builder.HasKey(e => e.Id).HasName("plants_pkey");
+
+        builder.ToTable("plants");
+
+        builder.Property(e => e.Id).HasColumnName("id");
+        builder.Property(e => e.Active)
+            .HasDefaultValue(true)
+            .HasColumnName("active");
+        builder.Property(e => e.CreatedAt)
+            .HasDefaultValueSql("CURRENT_TIMESTAMP")
+            .HasColumnName("created_at");
+        builder.Property(e => e.ImageUrl)
+            .HasMaxLength(255)
+            .HasColumnName("image_url");
+        builder.Property(e => e.LastWatered).HasColumnName("last_watered");
+        builder.Property(e => e.LightRequirements)
+            .HasMaxLength(50)
+            .HasColumnName("light_requirements");
+        builder.Property(e => e.Name)
+            .HasMaxLength(50)
+            .HasColumnName("name");
+        builder.Property(e => e.Species)
+            .HasMaxLength(120)
+            .HasColumnName("species");
+        builder.Property(e => e.UpdatedAt)
+            .HasDefaultValueSql("CURRENT_TIMESTAMP")
+            .HasColumnName("updated_at");
+        builder.Property(e => e.UserId).HasColumnName("user_id");
+        builder.Property(e => e.WateringInterval).HasColumnName("watering_interval");
+
+        builder.HasOne(d => d.User).WithMany(p => p.Plants)
+            .HasForeignKey(d => d.UserId)
+            .HasConstraintName("plants_user_id_fkey");
+    }
+}

--- a/src/back-end/PlantCare.Infra/Configurations/UsersConfiguration.cs
+++ b/src/back-end/PlantCare.Infra/Configurations/UsersConfiguration.cs
@@ -1,0 +1,48 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using PlantCare.Domain.Entities;
+
+namespace PlantCare.Infra.Configurations;
+
+public class UsersConfiguration : IEntityTypeConfiguration<User>
+{
+    public void Configure(EntityTypeBuilder<User> builder)
+    {
+        builder.HasKey(e => e.Id).HasName("users_pkey");
+
+        builder.ToTable("users");
+
+        builder.HasIndex(e => e.Email, "users_email_key").IsUnique();
+
+        builder.HasIndex(e => e.Username, "users_username_key").IsUnique();
+
+        builder.Property(e => e.Id).HasColumnName("id");
+        builder.Property(e => e.Active)
+            .HasDefaultValue(true)
+            .HasColumnName("active");
+            
+        builder.Property(e => e.CreatedAt)
+            .HasDefaultValueSql("CURRENT_TIMESTAMP")
+            .HasColumnName("created_at");
+            
+        builder.Property(e => e.Email)
+            .HasMaxLength(320)
+            .HasColumnName("email");
+            
+        builder.Property(e => e.Name)
+            .HasMaxLength(100)
+            .HasColumnName("name");
+            
+        builder.Property(e => e.PasswordHash)
+            .HasMaxLength(255)
+            .HasColumnName("password_hash");
+            
+        builder.Property(e => e.UpdatedAt)
+            .HasDefaultValueSql("CURRENT_TIMESTAMP")
+            .HasColumnName("updated_at");
+            
+        builder.Property(e => e.Username)
+            .HasMaxLength(50)
+            .HasColumnName("username");
+    }
+}

--- a/src/back-end/PlantCare.Infra/Data/PlantCareDbContext.cs
+++ b/src/back-end/PlantCare.Infra/Data/PlantCareDbContext.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using PlantCare.Domain.Entities;
+using PlantCare.Infra.Configurations;
 
 namespace PlantCare.Infra.Data;
 
@@ -8,82 +9,8 @@ public class PlantCareDbContext(DbContextOptions<PlantCareDbContext> options) : 
     
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        modelBuilder.Entity<User>(entity =>
-        {
-            entity.HasKey(e => e.Id).HasName("users_pkey");
-
-            entity.ToTable("users");
-
-            entity.HasIndex(e => e.Email, "users_email_key").IsUnique();
-
-            entity.HasIndex(e => e.Username, "users_username_key").IsUnique();
-
-            entity.Property(e => e.Id).HasColumnName("id");
-            entity.Property(e => e.Active)
-                .HasDefaultValue(true)
-                .HasColumnName("active");
-            
-            entity.Property(e => e.CreatedAt)
-                .HasDefaultValueSql("CURRENT_TIMESTAMP")
-                .HasColumnName("created_at");
-            
-            entity.Property(e => e.Email)
-                .HasMaxLength(320)
-                .HasColumnName("email");
-            
-            entity.Property(e => e.Name)
-                .HasMaxLength(100)
-                .HasColumnName("name");
-            
-            entity.Property(e => e.PasswordHash)
-                .HasMaxLength(255)
-                .HasColumnName("password_hash");
-            
-            entity.Property(e => e.UpdatedAt)
-                .HasDefaultValueSql("CURRENT_TIMESTAMP")
-                .HasColumnName("updated_at");
-            
-            entity.Property(e => e.Username)
-                .HasMaxLength(50)
-                .HasColumnName("username");
-        });
-        
-        modelBuilder.Entity<Plant>(entity =>
-        {
-            entity.HasKey(e => e.Id).HasName("plants_pkey");
-
-            entity.ToTable("plants");
-
-            entity.Property(e => e.Id).HasColumnName("id");
-            entity.Property(e => e.Active)
-                .HasDefaultValue(true)
-                .HasColumnName("active");
-            entity.Property(e => e.CreatedAt)
-                .HasDefaultValueSql("CURRENT_TIMESTAMP")
-                .HasColumnName("created_at");
-            entity.Property(e => e.ImageUrl)
-                .HasMaxLength(255)
-                .HasColumnName("image_url");
-            entity.Property(e => e.LastWatered).HasColumnName("last_watered");
-            entity.Property(e => e.LightRequirements)
-                .HasMaxLength(50)
-                .HasColumnName("light_requirements");
-            entity.Property(e => e.Name)
-                .HasMaxLength(50)
-                .HasColumnName("name");
-            entity.Property(e => e.Species)
-                .HasMaxLength(120)
-                .HasColumnName("species");
-            entity.Property(e => e.UpdatedAt)
-                .HasDefaultValueSql("CURRENT_TIMESTAMP")
-                .HasColumnName("updated_at");
-            entity.Property(e => e.UserId).HasColumnName("user_id");
-            entity.Property(e => e.WateringInterval).HasColumnName("watering_interval");
-
-            entity.HasOne(d => d.User).WithMany(p => p.Plants)
-                .HasForeignKey(d => d.UserId)
-                .HasConstraintName("plants_user_id_fkey");
-        });
+        modelBuilder.ApplyConfiguration(new UsersConfiguration());
+        modelBuilder.ApplyConfiguration(new PlantsConfiguration());
         
         base.OnModelCreating(modelBuilder);
     }


### PR DESCRIPTION
Este PR adiciona as classes de configuração de tabelas na camada Infra. Posteriormente, as configurações eram feitas diretamente na classe PlantCareDbContext. Agora, elas constam no diretório Configurations onde cada tabela tem sua classe Configuration