### PR TITLE
Atualizando propriedade do modelo de criar planta para bytes.

### DIFF
--- a/src/back-end/PlantCare.Application/Plants/Models/CreatePlantRequest.cs
+++ b/src/back-end/PlantCare.Application/Plants/Models/CreatePlantRequest.cs
@@ -5,7 +5,7 @@ public class CreatePlantRequest
     public required long UserId { get; set; }
     public required string Name { get; set; }
     public required string Species { get; set; }
-    public string? ImageHash { get; set; }
+    public string? ImageBytes { get; set; }
     public required TimeSpan WateringInterval { get; set; }
     public DateTime? LastWatered { get; set; }
     public string? LightRequirements { get; set; }

--- a/src/back-end/PlantCare.Application/Plants/Services/PlantsService.cs
+++ b/src/back-end/PlantCare.Application/Plants/Services/PlantsService.cs
@@ -68,7 +68,7 @@ public class PlantsService : IPlantsService
             UserId = req.UserId,
             Name = req.Name,
             Species = req.Species, 
-            ImageHash = req.ImageHash,
+            ImageHash = req.ImageBytes,
             WateringInterval = req.WateringInterval,
             LastWatered = req.LastWatered,
             LightRequirements = req.LightRequirements,

--- a/src/back-end/PlantCare.Application/Plants/Validators/CreatePlantRequestValidator.cs
+++ b/src/back-end/PlantCare.Application/Plants/Validators/CreatePlantRequestValidator.cs
@@ -19,8 +19,6 @@ public class CreatePlantRequestValidator : AbstractValidator<CreatePlantRequest>
             .NotEmpty().WithMessage("Species is required")
             .MinimumLength(10).WithMessage("Species must be at least 10 characters")
             .MaximumLength(120).WithMessage("Species cannot exceed 100 characters");
-        RuleFor(x => x.ImageHash)
-            .MaximumLength(64).WithMessage("ImageHash cannot exceed 64 characters");
         RuleFor(x => x.WateringInterval)
             .NotNull().WithMessage("Plant must have a watering interval");
         RuleFor(x => x.LightRequirements)


### PR DESCRIPTION
Este PR atualiza o modelo CreatePlantRequest para receber a propriedade da imagem em binario, mudando o nome da propriedade para ImageBytes e retirando a regras de validação que limitassem o tamanho da string