### PR TITLE
Implementando geração de hash (sha256) na criação da entidade planta

### DIFF
--- a/src/back-end/PlantCare.Application/Plants/Services/PlantsService.cs
+++ b/src/back-end/PlantCare.Application/Plants/Services/PlantsService.cs
@@ -68,7 +68,7 @@ public class PlantsService : IPlantsService
             UserId = req.UserId,
             Name = req.Name,
             Species = req.Species, 
-            ImageHash = req.ImageBytes,
+            ImageHash = req.ImageBytes is not null ? Utils.Utils.GetSha256Hash(req.ImageBytes) : null,
             WateringInterval = req.WateringInterval,
             LastWatered = req.LastWatered,
             LightRequirements = req.LightRequirements,

--- a/src/back-end/PlantCare.Application/Utils/Utils.cs
+++ b/src/back-end/PlantCare.Application/Utils/Utils.cs
@@ -1,0 +1,14 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace PlantCare.Application.Utils;
+
+public static class Utils
+{
+    public static string GetSha256Hash(string input)
+    {
+        byte[] inputBytes = Encoding.UTF8.GetBytes(input);
+        var inputHash = SHA256.HashData(inputBytes);
+        return Convert.ToHexString(inputHash);
+    }
+}


### PR DESCRIPTION
Este PR implementa um método simples que gera uma string hexadecial com sha256 que é utilizado no serviço de plantas no método CreateAsync.

Caso o front-end tenha enviado uma imagem (em bytes), uma string hexadecimal é gerada e salva na entidade planta, que é posteriormente persistida no banco de dados.

Essa string hexadecimal servirá para nomear o registro no bucket que persistirá as imagens